### PR TITLE
rspec tests - lint cleanups

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,8 @@
+fixtures:
+  repositories:
+    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+    "firewall": "git://github.com/puppetlabs/puppetlabs-firewall.git"
+    "mysql": "git://github.com/rochaporto/puppet-mysql.git"
+  symlinks:
+    "cloudstack": "#{source_dir}"
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ tests
 environments
 .idea
 *~
+Gemfile.lock
+.bundle
+vendor
+spec/fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: ruby
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.1.4
+script:
+  - "bundle exec rake spec SPEC_OPTS='--format documentation'"
+env:
+  - PUPPET_VERSION="~> 2.6.0"
+  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.0.0"
+  - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.8.0"
+  - PUPPET_VERSION="~> 4.2"
+matrix:
+  exclude:
+    - rvm: 1.8.7
+      env: PUPPET_VERSION="~> 4.2"
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 2.6.0"
+    - rvm: 2.1.4
+      env: PUPPET_VERSION="~> 2.6.0"
+    - rvm: 2.1.4
+      env: PUPPET_VERSION="~> 2.7.0"
+    - rvm: 2.1.4
+      env: PUPPET_VERSION="~> 3.0.0"
+    - rvm: 2.1.4
+      env: PUPPET_VERSION="~> 3.1.0"
+
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV['PUPPET_VERSION']
+gem 'puppet', puppetversion, :require => false
+gem 'puppet-lint'
+gem 'rspec', '~> 3.1.0',    :platforms => :ruby_18
+gem 'puppetlabs_spec_helper', '>= 0.1.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint'
+PuppetLint.configuration.send("disable_80chars")
+PuppetLint.configuration.send('disable_class_parameter_defaults')

--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -45,6 +45,6 @@ define cloudstack::cluster(
         "/usr/bin/curl \'${teststring_pod}\' | grep ${podid}",
         "/usr/bin/curl \'${teststring_cluster}\' | grep -v ${cluster}"
       ],
-      require => Exec[ 'cloud_setup_databases' ],
+      require => Exec[ 'cloudstack_setup_databases' ],
     }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,9 +43,8 @@ class cloudstack(
 
 
   yumrepo{ 'cloudstack':
-    descr   => 'Cloudstack repo 4.5',
+    descr    => 'Cloudstack repo 4.5',
     baseurl  => 'http://cloudstack.apt-get.eu/rhel/4.5/',
-    # baseurl  => 'http://cloudstack.apt-get.eu/rhel/4.4/',
     enabled  => '1',
     gpgcheck => '0',
   }

--- a/manifests/mgmt.pp
+++ b/manifests/mgmt.pp
@@ -72,20 +72,20 @@ class cloudstack::mgmt {
 
 
   file { '/etc/cloudstack/management/tomcat6.conf':
-    ensure => 'link',
-    group  => '0',
-    mode   => '0777',
-    owner  => '0',
-    target => 'tomcat6-nonssl.conf',
+    ensure  => 'link',
+    group   => '0',
+    mode    => '0777',
+    owner   => '0',
+    target  => 'tomcat6-nonssl.conf',
     require => Package[ 'cloudstack-management' ],
   }
 
   file { '/usr/share/cloudstack-management/conf/server.xml':
-    ensure => 'link',
-    group  => '0',
-    mode   => '0777',
-    owner  => '0',
-    target => 'server-nonssl.xml',
+    ensure  => 'link',
+    group   => '0',
+    mode    => '0777',
+    owner   => '0',
+    target  => 'server-nonssl.xml',
     require => Package[ 'cloudstack-management' ],
   }
 

--- a/manifests/nfs_common.pp
+++ b/manifests/nfs_common.pp
@@ -1,10 +1,10 @@
-# Class: cloudstack::nfs-common
+# Class: cloudstack::nfs_common
 #
 # this subclass provides NFS for primary and secondary storage
 # on a single machine. this is not production quality - but useful
 # for a POC/demo/dev/test environment.
 # you will either want to significantly alter or use your own nfs class
-class cloudstack::nfs-common {
+class cloudstack::nfs_common {
 
 
   package {'nfs-utils':

--- a/manifests/pod.pp
+++ b/manifests/pod.pp
@@ -40,6 +40,6 @@ define cloudstack::pod(
         "/usr/bin/curl \'${teststring_zone}\' | grep ${zoneid}",
         "/usr/bin/curl \'${teststring_pod}\' | grep -v ${pod}",
       ],
-      require => Exec[ 'cloud_setup_databases' ],
+      require => Exec[ 'cloudstack_setup_databases' ],
     }
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -32,6 +32,6 @@ define cloudstack::zone(
 
     exec { "/usr/bin/curl \'${reststring}\'":
       onlyif  => "/usr/bin/curl \'${teststring}\' | grep -v ${name}",
-      require => Exec[ 'cloud_setup_databases' ],
+      require => Exec[ 'cloudstack_setup_databases' ],
     }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'cloudstack' do
+    let(:node) { 'cloudstack.example42.com' }
+    let(:facts) {{
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :operatingsystemrelease => '12.10'
+    }}
+
+    describe 'generic test' do
+        it { should compile }
+        it { should contain_class('cloudstack') }
+    end
+end

--- a/spec/classes/kvmagent_spec.rb
+++ b/spec/classes/kvmagent_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'cloudstack::kvmagent' do
+    let(:node) { 'cloudstack.example42.com' }
+    let(:pre_condition) { 'include cloudstack' }
+    let(:facts) {{
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :operatingsystemrelease => '12.10'
+    }}
+
+    describe 'generic test' do
+        it { should compile }
+        it { should contain_class('cloudstack::kvmagent') }
+    end
+end

--- a/spec/classes/mgmt_spec.rb
+++ b/spec/classes/mgmt_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'cloudstack::mgmt' do
+    let(:node) { 'cloudstack.example42.com' }
+    let(:pre_condition) { 'include cloudstack' }
+    let(:facts) {{
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :operatingsystemrelease => '12.10'
+    }}
+
+    describe 'generic test' do
+        it { should compile }
+        it { should contain_class('cloudstack::mgmt') }
+    end
+end

--- a/spec/classes/nfs_common_spec.rb
+++ b/spec/classes/nfs_common_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'cloudstack::nfs_common' do
+    let(:node) { 'cloudstack.example42.com' }
+    let(:facts) {{
+        :osfamily => 'Debian',
+        :operatingsystem => 'Ubuntu',
+        :operatingsystemrelease => '12.10'
+    }}
+
+    describe 'generic test' do
+        it { should compile }
+        it { should contain_class('cloudstack::nfs_common') }
+    end
+end

--- a/spec/defines/cluster_spec.rb
+++ b/spec/defines/cluster_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'cloudstack::cluster', :type => :define do
+    let(:title) { 'example42' }
+    let(:facts) {{
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS'
+    }}
+    let(:params) {{
+        :zoneid => 'cloudstack',
+        :podid => 'example42'
+    }}
+    let(:pre_condition) {[
+        'include cloudstack',
+        'include cloudstack::mgmt',
+    ]}
+    it { should compile }
+end

--- a/spec/defines/pod_spec.rb
+++ b/spec/defines/pod_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe 'cloudstack::pod', :type => :define do
+    let(:title) { 'example42' }
+    let(:facts) {{
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS'
+    }}
+    let(:params) {{
+        :gateway => '127.0.0.1',
+        :netmask => '255.255.0.0',
+        :startip => '10.0.2.0',
+        :endip => '10.2.0.3',
+        :zoneid => 'example42'
+    }}
+    let(:pre_condition) {[
+        'include cloudstack',
+        'include cloudstack::mgmt'
+    ]}
+    it { should compile }
+end

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'cloudstack::zone', :type => :define do
+    let(:title) { 'example42' }
+    let(:facts) {{
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS'
+    }}
+    let(:pre_condition) {[
+        'include cloudstack',
+        'include cloudstack::mgmt'
+    ]}
+    it { should compile }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
Two lint issues:

manifests/cluster.pp line 46
    "/usr/bin/curl \'${teststring_cluster}\' | grep -v ${cluster}"
Where is $cluster declared?

manifests/pod.pp line 41
    "/usr/bin/curl \'${teststring_pod}\' | grep -v ${pod}",
Where is $pod declared?
